### PR TITLE
Add README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+What is this?
+=============
+
+Typing Turtle is an interactive touch typing program. It gradually introduces the keys on the keyboard through a series of lessons, until the student has learned the entire keyboard.
+
+How to use?
+===========
+
+Typing Turtle is part of the Sugar desktop.  Please refer to;
+
+* [How to Get Sugar on sugarlabs.org](https://sugarlabs.org/),
+* [How to use Sugar](https://help.sugarlabs.org/),
+* [How to use Typing Turtle](https://help.sugarlabs.org/typing_turtle.html)
+* [Localization Tips](docs/localization_tips.md)
+
+How to upgrade?
+===============
+
+On Sugar desktop systems;
+* use [My Settings](https://help.sugarlabs.org/en/my_settings.html), [Software Update](https://help.sugarlabs.org/en/my_settings.html#software-update), or;
+* use Browse to open [activities.sugarlabs.org](https://activities.sugarlabs.org/), search for `Typing Turtle`, then download.

--- a/docs/localization_tips.md
+++ b/docs/localization_tips.md
@@ -1,0 +1,5 @@
+### Localizing Typing Turtle
+
+As with any other Sugar activity, Typing Turtle is translated using [Pootle](translate.sugarlabs.org).  Pootle displays the translatable strings from the newest version of the activity and allows them to be translated into a different language.  When translations are saved, the author is notified and will then release a new version to activities.sugarlabs.org with the new translations.  
+
+Typing Turtle's lesson content is too complex to be translated the same way, and must be created from scratch for each language and keyboard layout.  Use the lesson editor feature to create a new set of lessons for your language and keyboard layout, export the lessons to the Journal, and email them to the author.  They will be included in the next version.


### PR DESCRIPTION
Documentation of this activity was recently migrated from the wiki.
See https://github.com/godiard/help-activity/pull/56

This PR adds a basic README where 'How to use Typing Turtle' points to the migrated user-documentation.
Added *'docs/localization_tips'* as was available in https://wiki.sugarlabs.org/go/Activities/Level_Tool

Feel free to add/subtract information as necessary from the README.md file.